### PR TITLE
Configure commonjs plugin for rollup build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,12 @@ const config = {
   },
   plugins: [
     resolve({browser: true, preferBuiltins: false}),
-    commonJs(),
+    commonJs({
+      ignoreGlobal: false,
+      include: /node_modules/,
+      // Handle 'this' in top-level scope correctly for Supabase and other CommonJS modules
+      requireReturnsDefault: 'auto'
+    }),
     replace({
       'process.env.NODE_ENV': nodeEnv,
       'process?.env?.NODE_ENV': nodeEnv,


### PR DESCRIPTION
Update Rollup CommonJS plugin configuration to fix build error with `this` being rewritten to `undefined` in `@supabase/supabase-js`.

The build was failing because `@supabase/supabase-js` uses CommonJS features that caused `this` to be rewritten to `undefined` in strict mode. Configuring `@rollup/plugin-commonjs` with `requireReturnsDefault: 'auto'` prevents this rewriting, ensuring proper module bundling.

---
<a href="https://cursor.com/background-agent?bcId=bc-02beda1b-fd0b-4a4b-b0a5-b6153a6302a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02beda1b-fd0b-4a4b-b0a5-b6153a6302a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

