### PR TITLE
Fix rollup this context error for supabase

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,16 +13,31 @@ const config = {
     inlineDynamicImports: true
   },
   plugins: [
-    resolve({browser: true, preferBuiltins: false}),
+    // CommonJS plugin should come before resolve to properly handle node_modules
     commonJs({
       ignoreGlobal: false,
       include: /node_modules/,
       // Handle 'this' in top-level scope correctly for Supabase and other CommonJS modules
-      requireReturnsDefault: 'auto'
+      requireReturnsDefault: 'auto',
+      // Additional options to better handle CommonJS modules
+      transformMixedEsModules: true,
+      // Fix for "this" context issue with @supabase/supabase-js
+      // This will properly handle the TypeScript helper functions
+      strictRequires: false
     }),
+    resolve({browser: true, preferBuiltins: false}),
     replace({
       'process.env.NODE_ENV': nodeEnv,
       'process?.env?.NODE_ENV': nodeEnv,
+      // Fix "this" issue by replacing it with globalThis in problematic contexts
+      'this && this.__awaiter': 'globalThis && globalThis.__awaiter',
+      'this && this.__generator': 'globalThis && globalThis.__generator',
+      'this && this.__importDefault': 'globalThis && globalThis.__importDefault',
+      'this && this.__exportStar': 'globalThis && globalThis.__exportStar',
+      'this && this.__createBinding': 'globalThis && globalThis.__createBinding',
+      'this && this.__setModuleDefault': 'globalThis && globalThis.__setModuleDefault',
+      'this && this.__importStar': 'globalThis && globalThis.__importStar',
+      'this && this.__rest': 'globalThis && globalThis.__rest',
       preventAssignment: true
     }),
     terser({

--- a/scripts/get-bundle-sizes.js
+++ b/scripts/get-bundle-sizes.js
@@ -1,7 +1,7 @@
 import {readFile} from 'fs/promises'
 import {brotliCompress} from 'zlib'
 
-const pkgs = ['firebase', 'ipfs', 'mqtt', 'nostr', 'supabase', 'torrent']
+const pkgs = ['firebase', 'ipfs', 'mqtt', 'nostr', 'supabase', 'torrent', 'game']
 const longest = pkgs.sort((a, b) => b.length - a.length)[0].length
 
 Promise.all(

--- a/src/game.d.ts
+++ b/src/game.d.ts
@@ -1,6 +1,37 @@
-/**
- * TypeScript definitions for Trystero Game Module
- */
+export {
+  initGameEngine,
+  createGameInstance,
+  processGameAction,
+  getGameState,
+  updateGame,
+  addPlayer,
+  removePlayer,
+  destroyGameInstance,
+  onGameEvent,
+  isInitialized,
+  getExports
+} from './wasm/game-engine'
 
-export * from './wasm/game-engine'
-export * from './wasm/game-room'
+export {
+  createGameRoom,
+  createGameRoomFromUrl,
+  defaultGameConfig
+} from './wasm/game-room'
+
+// Re-export types for TypeScript users
+export type {
+  GameConfig,
+  GameState,
+  PlayerState,
+  GameAction,
+  GameUpdateResult,
+  GameEvent,
+  WasmSource,
+  WasmImports,
+  WasmExports
+} from './wasm/game-engine'
+
+export type {
+  GameRoom,
+  GameRoomConfig
+} from './wasm/game-room'

--- a/src/game.js
+++ b/src/game.js
@@ -23,20 +23,5 @@ export {
   defaultGameConfig
 } from './wasm/game-room.js'
 
-// Re-export types for TypeScript users
-export type {
-  GameConfig,
-  GameState,
-  PlayerState,
-  GameAction,
-  GameUpdateResult,
-  GameEvent,
-  WasmSource,
-  WasmImports,
-  WasmExports
-} from './wasm/game-engine.js'
-
-export type {
-  GameRoom,
-  GameRoomConfig
-} from './wasm/game-room.js'
+// Type exports are handled in the .d.ts file
+// JavaScript modules don't need to export types

--- a/src/wasm/game-room.js
+++ b/src/wasm/game-room.js
@@ -3,7 +3,6 @@
  * Integrates WASM game logic with P2P room functionality
  */
 
-import {makeAction} from '../room.js'
 import {
   initGameEngine,
   createGameInstance,
@@ -18,7 +17,7 @@ import {
 } from './game-engine.js'
 
 // Game room configuration defaults
-const defaultGameConfig = {
+export const defaultGameConfig = {
   tickRate: 60, // Game updates per second
   syncInterval: 100, // State sync interval in ms
   maxPlayers: 8,
@@ -54,12 +53,12 @@ export const createGameRoom = async (room, wasmSource, gameConfig = {}) => {
   const playerStates = new Map()
   const actionQueue = []
   
-  // Create game-specific actions
-  const [sendGameAction, receiveGameAction] = makeAction('gameAction')
-  const [sendStateSync, receiveStateSync] = makeAction('stateSync')
-  const [sendPlayerJoin, receivePlayerJoin] = makeAction('playerJoin')
-  const [sendPlayerLeave, receivePlayerLeave] = makeAction('playerLeave')
-  const [sendHostTransfer, receiveHostTransfer] = makeAction('hostTransfer')
+  // Create game-specific actions using the room's makeAction method
+  const [sendGameAction, receiveGameAction] = room.makeAction('gameAction')
+  const [sendStateSync, receiveStateSync] = room.makeAction('stateSync')
+  const [sendPlayerJoin, receivePlayerJoin] = room.makeAction('playerJoin')
+  const [sendPlayerLeave, receivePlayerLeave] = room.makeAction('playerLeave')
+  const [sendHostTransfer, receiveHostTransfer] = room.makeAction('hostTransfer')
   
   // Enhanced room object
   const gameRoom = {


### PR DESCRIPTION
Fix Rollup build errors for `@supabase/supabase-js` and the `game` module by adjusting Rollup config and module exports.

The primary issue was Rollup's 'this' context handling for `@supabase/supabase-js`, addressed by configuring the CommonJS plugin and replacing TypeScript helpers with `globalThis`. The `game` module also required fixes for type exports, a missing `defaultGameConfig` export, and correcting the usage of `makeAction` to be a method of the `room` instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-b011e834-66a1-4235-9e89-6c62d35176e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b011e834-66a1-4235-9e89-6c62d35176e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

